### PR TITLE
Added Docker setup for EAs.LiT

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 ![EAs.LiT Logo](Logo_EAs.LiT.png)
 
-
 ## Install
-* Install Wordpress on Apache Server
-* (braucht es nicht mehr: Add [Multiple Roles Plugin](https://de.wordpress.org/plugins/multiple-roles/)) 
-* Add EAs.LiT plugin
-* Configure config_taxonomies.php
-* Increase Apache File Upload Size (2MB is usually too small if you want to upload items)
-* Set date / time format and time zone 
-* Set Start Page
 
-* PHP Extension: STATS (für die Korrelationen bei der Testanalyse)
+Tested with
+[![Wordpress](https://img.shields.io/badge/Wordpress-v4.9-lightgrey.svg)](https://wordpress.org/download/)
+[![PHP](https://img.shields.io/badge/PHP-v7.2-lightgrey.svg)](https://secure.php.net/)
 
-(braucht es doch nicht: php extensions: ds, gmp)
+EAs.LiT may be installed to some server running Apache and PHP or by using a docker setup. For docker, have a look at the README.md inside the docker folder.The following enumeration describes steps to setup EAs.LiT without docker.
 
+1. Set up a webserver, [install Apache and PHP](https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-ubuntu-18-04)
+2. [Install Wordpress](https://codex.wordpress.org/Installing_WordPress) to the server
+3. [Add EAs.LiT plugin](https://www.dummies.com/web-design-development/wordpress/templates-themes-plugins/how-to-install-wordpress-plugins-manually/) to the installed wordpress
+4. Configure the file config_taxonomies.php as needed
+5. [Increase Apache File Upload Size](https://www.cyberciti.biz/faq/increase-file-upload-size-limit-in-php-apache-app/) (default vaule (2MB) is usually too small if you want to upload items)
+6. Set date/time format and time zone in wordpress
+7. Set up a Start Page
 
-max_input_vars = 1000000
-post_max_size=100M
-upload_max_filesize=200M
+PHP Extension "STATS" is needed for correlations inside the test analysis.
+
+## Comments
+max_input_vars = 1000000  
+post_max_size=100M  
+upload_max_filesize=200M  

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM wordpress:4.9
+LABEL maintainer="roy.meissner@uni-leipzig.de"
+
+RUN mkdir -p /usr/src/wordpress/wp-content/plugins/eal
+COPY ./ /usr/src/wordpress/wp-content/plugins/eal/

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,8 @@ To set up a new wordpress instance for testing purposes with the plugin installe
 6. login as admin and activate the EAs.LiT plugin + create a new user with role author
 7. logout & login as this new user to use the plugin
 
+EAs.LiT will print all warnings and errors by default to the page. See [Production](#production) for information an how to change this behaviour.
+
 ## Production
 
 To deploy EAs.LiT as a new wordpress instance, do:
@@ -26,6 +28,8 @@ To deploy EAs.LiT as a new wordpress instance, do:
 6. wait some seconds to get letsencypt certificates (HTTPS)
 7. navigate to the URL you added to VIRTUAL_HOST and set up Wordpress
 8. follow steps 6. and 7. of the [Testing](#testing) section
+
+**Errors and Warnings** are printed by default to the page. To disable this, add `error_reporting(0);` to easlit_plugin.php, e.g. after the inital comment, and continue with step 3.
 
 ## TODO
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,33 @@
+# Docker and docker-compose usage
+
+The EAs.LiT wordpress plugin my be set up as a new wordpress deployment or for testing purposes. To ease this process, use the steps given in the following sections.
+
+## Testing
+
+To set up a new wordpress instance for testing purposes with the plugin installed, do the following
+
+1. `docker-compose up -d db` to start the db container
+2. wait for the db to initialize (typically about 10 seconds)
+3. `docker-compose build` to create a wordpress image with EAs.LiT plugin installed (not activated yet)
+4. `docker-compose up -d wordpress` to start the wordpress at port 8080
+5. navigate to "localhost:8080" and set up Wordpress
+6. login as admin and activate the EAs.LiT plugin + create a new user with role author
+7. logout & login as this new user to use the plugin
+
+## Production
+
+To deploy EAs.LiT as a new wordpress instance, do:
+
+1. include all commented lines in the docker-compose.yml. pay attention to genera comments
+2. `docker-compose up -d db` to start the db container
+3. wait for the db to initialize (typically about 10 seconds)
+4. `docker-compose build` to create a wordpress image with EAs.LiT plugin installed (not activated yet)
+5. `docker-compose up -d` to start all remaining containers
+6. wait some seconds to get letsencypt certificates (HTTPS)
+7. navigate to the URL you added to VIRTUAL_HOST and set up Wordpress
+8. follow steps 6. and 7. of the [Testing](#testing) section
+
+## TODO
+
+* use docker-compose file stapling ([-f option](https://docs.docker.com/compose/reference/overview/#use--f-to-specify-name-and-path-of-one-or-more-compose-files)) instead of comments
+* verify setup for errors and warnings

--- a/docker/client_max_body_size.conf
+++ b/docker/client_max_body_size.conf
@@ -1,0 +1,1 @@
+client_max_body_size 512m;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,9 @@ services:
   #     - nginx
 
   wordpress:
-    image: wordpress:4.9
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
     # restart: always
     environment:
       # - VIRTUAL_HOST=example.org
@@ -38,6 +40,7 @@ services:
       # - LETSENCRYPT_EMAIL=example@mail.example.org
       - WORDPRESS_DB_HOST=db:3306
       - WORDPRESS_DB_PASSWORD=WEig3MNl
+    # exclude ports section and include expose section when using nginx
     ports:
       - "8080:80"
     # expose:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,71 @@
+version: '2'
+
+services:
+  # nginx:
+  #   image: jwilder/nginx-proxy
+  #   restart: unless-stopped
+  #   ports:
+  #     - 80:80
+  #     - 443:443
+  #   networks:
+  #     - front-trier
+  #   volumes:
+  #     - /var/run/docker.sock:/tmp/docker.sock:ro
+  #     - ./client_max_body_size.conf:/etc/nginx/conf.d/client_max_body_size.conf:ro
+  #     - ./certs:/etc/nginx/certs:ro
+  #     - ./vhost.d:/etc/nginx/vhost.d
+  #     - /usr/share/nginx/html
+
+  # letsencrypt:
+  #   image: jrcs/letsencrypt-nginx-proxy-companion
+  #   restart: unless-stopped
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock:ro
+  #     - ./certs:/etc/nginx/certs:rw
+  #   networks:
+  #     - front-trier
+  #   volumes_from:
+  #     - nginx
+  #   depends_on:
+  #     - nginx
+
+  wordpress:
+    image: wordpress:4.9
+    # restart: always
+    environment:
+      # - VIRTUAL_HOST=example.org
+      # - LETSENCRYPT_HOST=example.org
+      # - LETSENCRYPT_EMAIL=example@mail.example.org
+      - WORDPRESS_DB_HOST=db:3306
+      - WORDPRESS_DB_PASSWORD=WEig3MNl
+    ports:
+      - "8080:80"
+    # expose:
+       # - 80
+    networks:
+      - front-trier
+      - back-trier
+    volumes:
+      - wp-html:/var/www/html:rw
+    depends_on:
+       - db
+       # - nginx
+
+  db:
+    image: mariadb:10
+    # restart: always
+    networks:
+      - back-trier
+    volumes:
+      - db-data:/var/lib/mysql:rw
+    environment:
+      # Change default PW for actual deployment!
+      - MYSQL_ROOT_PASSWORD=WEig3MNl
+
+networks:
+  front-trier: {}
+  back-trier: {}
+
+volumes:
+  wp-html: {}
+  db-data: {}


### PR DESCRIPTION
I've added a docker setup for EAs.LiT to ease setup and deploy activities. Usage is described in the readme files.

According to my tests, EAs.LiT works with PHP 7.2 and Wordpress 4.9.